### PR TITLE
Fix analytics

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -83,6 +83,9 @@
     //
     // track any stage change in gAnalytics
     //
+    if(Cryptoloji.stateman.current){
+      ga('send', 'pageview', Cryptoloji.stateman.current.name);
+    }
     Cryptoloji.stateman.on('begin', function (e) {
       ga('send', 'pageview', e.path);
     })
@@ -99,8 +102,13 @@
     Cryptoloji.stateman.on('decrypt:right-key', function(){
       ga('send', 'event', 'decrypt', 'right-key');
     })
-    Cryptoloji.stateman.on('encrypt:key', function(){
-      ga('send', 'event', 'encrypt', 'key');
+    Cryptoloji.stateman.on('encrypt:key', function(key){
+      if(key){
+        ga('send', 'event', 'encrypt', 'key');
+      }else{
+        ga('send', 'event', 'encrypt', 'key_first');
+      }
+      
     })
     Cryptoloji.stateman.on('encrypt:key_soon', function(){
       ga('send', 'event', 'encrypt', 'key_soon');

--- a/assets/js/states/encrypt.js
+++ b/assets/js/states/encrypt.js
@@ -49,13 +49,12 @@
             animateInputPlaceholder(theater, newplaceholder)
             Cryptoloji.stateman.emit('encrypt:key_soon')
           }
-
           // check if the key is already being selected
           // this avoid multiple call from slider and modal
           if (Cryptoloji.current.key !== key) {
             Cryptoloji.UI.selectKey(key)
 
-            Cryptoloji.stateman.emit('encrypt:key')
+            Cryptoloji.stateman.emit('encrypt:key', currkey)
 
             // select corresponding emoji in keymodal
             Cryptoloji.UI.KeyModal().select(key)
@@ -67,10 +66,11 @@
         Cryptoloji.stateman.on('keymodal:key-chosen', function (key) {
           // check if the key is already being selected
           // this avoid multiple call from slider and modal
+          var currkey = Cryptoloji.current.key
           if (Cryptoloji.current.key !== key) {
             Cryptoloji.UI.selectKey(key)
 
-            Cryptoloji.stateman.emit('encrypt:key')
+            Cryptoloji.stateman.emit('encrypt:key', currkey)
 
             Cryptoloji.UI.Keyslider('encrypt')
               .resetSelection()
@@ -81,9 +81,9 @@
         })
       } else {
         Cryptoloji.stateman.on('keypanel:key-chosen', function (key) {
-
+          var currkey = Cryptoloji.current.key
           Cryptoloji.UI.selectKey(key)
-          Cryptoloji.stateman.emit('encrypt:key')
+          Cryptoloji.stateman.emit('encrypt:key', currkey)
           $('#encryption_selected_key').html(Cryptoloji.UI.toTwemoji(key))
           // coachmark error
           if (_.isEmpty($('#encryption_input').val())) {

--- a/index.html
+++ b/index.html
@@ -261,10 +261,10 @@
           <p id="landing_state_1_encrypted_message" class="landing_encrypted_message" landing-state="1">
             <!-- js injected -->
           </p>
-          <button class="mozilla_button" id="landing_state_1_button" to-state="decrypt" landing-state="1" track="decrypt__decipher">
+          <button class="mozilla_button" id="landing_state_1_button" to-state="decrypt" landing-state="1" track="landing__decipherit">
             Decipher it
           </button>
-          <a class="Learn_more_button footer_link" landing-state="1" id="landing_state_1_more"
+          <a track="decrypt__learnmore" class="Learn_more_button footer_link" landing-state="1" id="landing_state_1_more"
              href="https://advocacy.mozilla.org/encrypt/codemoji" target="_blank">
             Learn more about encryption
           </a>
@@ -591,7 +591,7 @@
 
   <div class="section learnmore_popup_share" layout="row" layout-align="center center">
     <div class="svg_wrapper svg_wrapper_books" data-svg="assets/svg/books.svg" layout="row" layout-align="center center"></div>
-    <div><a href="https://advocacy.mozilla.org/encrypt/codemoji" target="blank">Learn more about how modern Encryption works</a></div>
+    <div><a track="share__learnmore" href="https://advocacy.mozilla.org/encrypt/codemoji" target="blank">Learn more about how modern Encryption works</a></div>
   </div>
   <!-- SHARE views/share -->
   <div color-bg-dark class="section_share section" layout="column" layout-align="start center">
@@ -873,7 +873,7 @@ _l('app.js?v=<%=version%>');
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
   ga('create', 'UA-7954920-12', 'auto');
-  ga('send', 'pageview');
+  //ga('send', 'pageview'); // handled in app.js
 
 </script>
 


### PR DESCRIPTION
Here the fixes & adds about some tracking details discussed in call:

- Learn more link in Share view is tracked in events as ```learnmore``` action
- now there are ```welcome``` and ```landing``` virtual pageview tracked instead of a generic root path
- 'decipher it' button is now tracked in ```landing``` category as ```decipherit``` action
- the first emoji chosen in encrypt will be tracked as ```key_first``` action event then the following keys will be tracked as ```key``` action event.

cc/ @ScottDowne @lovegushwa @cadecairos 