### PR TITLE
Fix issue with `undefined` in encrypted text view

### DIFF
--- a/assets/js/ui.js
+++ b/assets/js/ui.js
@@ -142,17 +142,39 @@
     letterEmoji = letterEmoji.join('')
     return letterEmoji
   }
-  
+
+  function _getEmojiTextElements (twemojifiedText) {
+    // get list of independent elements from twemojified string
+
+    var emojiElems = []
+
+    // Use jQuery.parseHTML to detect independent HTML elements
+    // in the twemojified text
+    $.parseHTML(twemojifiedText).forEach(function (elem) {
+      // if element is a tag just put its string representation 
+      // into array of elements
+      if (elem.nodeType === Node.ELEMENT_NODE) {
+        emojiElems.push(elem.outerHTML)
+      } else {
+        // In this case we deal with unprocessed characters.
+        // Add every character to array of elements
+        Array.prototype.push.apply(emojiElems, elem.nodeValue.split(''))
+      }
+    })
+
+    return emojiElems
+  }
+
   function _generateEmojFromBlueBox (blueBoxText, emojiText) {
     emojiText = toTwemoji(emojiText)
     // load emoji text to share
     $('.share_message_item').html(emojiText)
+    var emojiElems = _getEmojiTextElements(emojiText)
 
-    emojiText = emojiText.replace(/>/g, '>,').split(',')
     var emojiOut = _.map(blueBoxText, function (bb, idx) {
       var openspan = '<span class="' + $(bb).attr('class') + '">'
       var closespan = '</span>'
-      return openspan + emojiText[idx] + closespan
+      return openspan + emojiElems[idx] + closespan
     })
     return emojiOut
   }


### PR DESCRIPTION
Issue
=====
An issue with view happened when user tried to encrypt characters which
do not belong to defined charlist. If there were two or more such
characters in a row, the 'undefined' word appeared in the view field.

To reproduce the issue you can try to encrypt some cyrillic text. For
example you can try this: "Привіт, світе!" (which means "Hello world!")

Here is how it looks:
![image](https://cloud.githubusercontent.com/assets/6533582/16433787/9cfcd694-3d94-11e6-9f19-082f9a790249.png)


Problem
-------
The problem is hidden here: https://github.com/mozilla/codemoji/blob/master/assets/js/ui.js#L151

When you try to display a text with unknown characters like "Привіт,
світе!" it will be transformed with twemoji function into something like
this: `"Привіт<img ...> світе<img ...>"`. After regexp_replace and split
occur that is transformed into the list of two elements: `["Привіт<img ...>", " світе<img ...>"]`

And when you try to access 3,4,5, and so forth element on line 155:
https://github.com/mozilla/codemoji/blob/master/assets/js/ui.js#L155 it
returnes undefined which is displayed later.

P.S. I may make some mistakes about handling whitespaces, for example,
but the problem in general is the same as I described.

Solution
--------
The solution is to find a better way to split that twemojified string
into elements.

Commit
======
This commit provides a solution to the described issue. As there is
jQuery loaded into that module, I use it to split twemojified string
into the list of DOM Elements. If the element is an Element node, I use
its string representation to build the output. Otherwise I assume that
it is a Text node. I split it character by character and add each
character as separate character to splitted elements list.

Then I use that list to build final result