### PR TITLE
fixes the query params check for determining whether to decrypt

### DIFF
--- a/assets/js/storage.js
+++ b/assets/js/storage.js
@@ -17,7 +17,7 @@
     // get query params
     var queryValues = uri.queryGet()
     // is there is something
-    if (!_.isEmpty(queryValues)) {
+    if (!_.isEmpty(queryValues) && queryValues.data) {
       // dehashify
       STORAGE = _dehashify(queryValues.data)
       // clean url


### PR DESCRIPTION
fixes https://github.com/MozillaFoundation/Advocacy/issues/111, *I think*, by making sure to check for a `data` query argument, rather than just "are there query argments". In the case of https://github.com/MozillaFoundation/Advocacy/issues/111 there are query arguments but they do not represent data that should be decrypted, and so the current code as used forgets to check whether there is a queryValues.data before then calleding dehash(queryValues.data).

I was able to reproduce the problem mentioned in the issue by running codemoji locally and hitting up http://localhost:3000/?utm_source=desktop%20snippet&amp;utm_medium=snippet&amp;utm_campaign=codemoji -- without this fix, it does the same thing (robot loader, then a white page), with the fix in place the welcome page will load just fine because no dehashing is attempted with a missing query argument.